### PR TITLE
Failing healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN export samba_version=4.8.4 \
                           perl \
                           perl-modules \
                           pkg-config \
+                          procps \
                           python-all-dev \
                           python-dev \
                           python-dnspython \


### PR DESCRIPTION
The health check script uses ps to check if smb is running. The base image doesn't contain the necessary package though. Installing `procps`should be sufficient to solve this issue.