### PR TITLE
Add support for multi-line strings in SAMBA_VOLUME_CONFIG_ variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ This is a Samba Server Container running on `_/alpine`.
     * multiple variables/confgurations possible by adding unique configname to SAMBA_VOLUME_CONFIG_
     * take a look at https://wiki.samba.org/index.php/Configure_Samba_to_Work_Better_with_Mac_OS_X -> EXPLANATION OF VOLUME PARAMETERS
     * seperate multiple lines using `;` which will be automatically translated to `\n`
+      * alternately, use multi-lines strings directly in the environment variables.  You can do this in docker-compose by using the yaml block style indicator `|`.  See example in `docker-compose.yml`
     * if your path variable ends with `%U` e.g. `path = /shares/homes/%U;` multi user mode gets activated and each user gets their own subdirectory for their own share. (great for timemachine - every user get's his own personal share)
     * for timemachine only add `fruit:time machine = yes` and all other needed settings are automatically added
         * you can also use `fruit:time machine max size = 500G;` to limit max size of time machine volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,11 @@ services:
       SAMBA_VOLUME_CONFIG_public_ro: "[Public ReadOnly]; path=/shares/public; guest ok = yes; read only = yes; browseable = yes; force group = family"
       
       SAMBA_VOLUME_CONFIG_timemachine: "[TimeMachine]; path=/shares/timemachine/%U; valid users = alice, bob, foo; guest ok = no; read only = no; browseable = yes; fruit:time machine = yes; fruit:time machine max size = 500G"
+      SAMBA_VOLUME_CONFIG_multiline: |
+        [guest]
+        path = /shares/someshare
+        guest ok = yes
+        browseable = yes
     volumes:
       - /etc/avahi/services/:/external/avahi
       

--- a/scripts/create-hash.sh
+++ b/scripts/create-hash.sh
@@ -14,7 +14,7 @@ echo
 
 if [ "$PASSWORD_1" == "$PASSWORD_2" ] && [ "$PASSWORD_1" != "" ] && [ "$USERNAME" != "" ]
 then
-  adduser -D -H -s /bin/false "$USERNAME" 2> /dev/null >/dev/null
+  adduser  --disabled-password --no-create-home --shell /bin/false --gecos "Samba user $USERNAME" "$USERNAME" 2> /dev/null >/dev/null
   smbpasswd -a -n "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | passwd "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | smbpasswd "$USERNAME" 2> /dev/null >/dev/null

--- a/scripts/create-hash.sh
+++ b/scripts/create-hash.sh
@@ -18,7 +18,8 @@ then
   smbpasswd -a -n "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | passwd "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | smbpasswd "$USERNAME" 2> /dev/null >/dev/null
-  cat /var/lib/samba/private/smbpasswd | grep ':$' | grep '^'"$USERNAME"':[0-9]*:'
+  SMBPASSWD_FILE=$(testparm -s -v 2> /dev/null | grep 'smb passwd file' | cut -d= -f2- | sed 's/^ \+//')
+  cat "$SMBPASSWD_FILE" | grep ':$' | grep '^'"$USERNAME"':[0-9]*:'
   exit 0
 fi
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -121,11 +121,13 @@ if [ ! -f "$INITALIZED" ]; then
   ##
   # Samba Volume Config ENVs
   ##
-  for I_CONF in $(env | grep '^SAMBA_VOLUME_CONFIG_')
+  for I_CONF in $(env | grep '^SAMBA_VOLUME_CONFIG_' | cut -d'=' -f1)
   do
-    CONF_CONF_VALUE=$(echo "$I_CONF" | sed 's/^[^=]*=//g')
+    # https://www.unix.com/linux/132018-how-get-indirect-variable-value.html
+    eval CONF_VAR=\$$I_CONF
+    CONF_CONF_VALUE="$CONF_VAR"
 
-    VOL_NAME=$(echo "$CONF_CONF_VALUE" | sed 's/.*\[\(.*\)\].*/\1/g')
+    VOL_NAME=$(echo "$CONF_CONF_VALUE" | head -n 1 | sed 's/.*\[\(.*\)\].*/\1/g')
     VOL_PATH=$(echo "$CONF_CONF_VALUE" | tr ';' '\n' | grep path | sed 's/.*= *//g')
 
     echo ">> VOLUME: adding volume: $VOL_NAME (path=$VOL_PATH)"


### PR DESCRIPTION
I have added an example of the updated format in the sample docker-compose.yml.  This makes it a lot more readable in my opinion

Reference: https://yaml-multiline.info/