### PR TITLE
Change adduser to useradd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PATH="/container/scripts:${PATH}"
 RUN apk add --no-cache runit \
                        avahi \
                        samba \
+                       shadow \
  \
  && sed -i 's/#enable-dbus=.*/enable-dbus=no/g' /etc/avahi/avahi-daemon.conf \
  && rm -vf /etc/avahi/services/* \

--- a/scripts/create-hash.sh
+++ b/scripts/create-hash.sh
@@ -14,7 +14,7 @@ echo
 
 if [ "$PASSWORD_1" == "$PASSWORD_2" ] && [ "$PASSWORD_1" != "" ] && [ "$USERNAME" != "" ]
 then
-  adduser -D -H -s /bin/false "$USERNAME" 2> /dev/null >/dev/null
+  useradd -u "$ACCOUNT_UID" -s /bin/false "$ACCOUNT_NAME" 2> /dev/null >/dev/null
   smbpasswd -a -n "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | passwd "$USERNAME" 2> /dev/null >/dev/null
   echo -e "$PASSWORD_1\n$PASSWORD_1" | smbpasswd "$USERNAME" 2> /dev/null >/dev/null

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -71,7 +71,7 @@ if [ ! -f "$INITALIZED" ]; then
     GROUP_NAME=$(echo "$I_CONF" | sed 's/^GROUP_//g' | sed 's/=.*//g')
     GROUP_ID=$(echo "$I_CONF" | sed 's/^[^=]*=//g')
     echo ">> GROUP: adding group $GROUP_NAME with GID: $GROUP_ID"
-    addgroup -g "$GROUP_ID" "$GROUP_NAME"
+    groupadd -g "$GROUP_ID" "$GROUP_NAME"
   done
 
   ##

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -87,10 +87,10 @@ if [ ! -f "$INITALIZED" ]; then
     if [ "$ACCOUNT_UID" -gt 0 ] 2>/dev/null
     then
       echo ">> ACCOUNT: adding account: $ACCOUNT_NAME with UID: $ACCOUNT_UID"
-      adduser -D -H -u "$ACCOUNT_UID" -s /bin/false "$ACCOUNT_NAME"
+      useradd -u "$ACCOUNT_UID" -s /bin/false "$ACCOUNT_NAME"
     else
       echo ">> ACCOUNT: adding account: $ACCOUNT_NAME"
-      adduser -D -H -s /bin/false "$ACCOUNT_NAME"
+      useradd -s /bin/false "$ACCOUNT_NAME"
     fi
     smbpasswd -a -n "$ACCOUNT_NAME"
 


### PR DESCRIPTION
I get my UID from an AD which uses very large number. 
adduser and addgroup commands does not accept these large numbers (at least not in this alpine version)

```
adduser: number 1304035270 is not in 0..256000 range
addgroup: number 1304000513 is not in 0..256000 range
```
When creating users and groups change to useradd and groupadd


Signed-off-by: Kjeld Flarup <kfa@deif.com>