### PR TITLE
Add rack mount Mac Pro to MODEL var description

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This is a Samba Server Container running on `_/alpine`.
 * __MODEL__
     * _optional_ model value of avahi samba service
     * _default:_ `TimeCapsule`
-    * some available options are Xserve, PowerBook, PowerMac, Macmini, iMac, MacBook, MacBookPro, MacBookAir, MacPro, MacPro6,1, TimeCapsule, AppleTV1,1 and AirPort.
+    * some available options are Xserve, PowerBook, PowerMac, Macmini, iMac, MacBook, MacBookPro, MacBookAir, MacPro, MacPro6,1, MacPro7,1@ECOLOR=226,226,224, TimeCapsule, AppleTV1,1 and AirPort.
 
 * __AVAHI\_NAME__
     * _optional_ name of avahi samba service


### PR DESCRIPTION
<img width="100" alt="image" src="https://user-images.githubusercontent.com/8362329/163791406-0d21ead2-da97-497e-ab2d-f4c416cf48a1.png">

The model icon is a modern rack mounted Mac from 2019 which fits really well with my rack mounted server! I thought it would be a good idea to share it with more people.

`MacPro7,1` on its own shows the tower version