### PR TITLE
seperate user generation and group assignment

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -124,7 +124,10 @@ if [ ! -f "$INITALIZED" ]; then
     fi
     
     smbpasswd -e "$ACCOUNT_NAME"
+  done
 
+  for I_ACCOUNT in $(env | grep '^ACCOUNT_')
+  do
     # add user to groups...
     ACCOUNT_GROUPS=$(env | grep '^GROUPS_'"$ACCOUNT_NAME" | sed 's/^[^=]*=//g')
     for GRP in $(echo "$ACCOUNT_GROUPS" | tr ',' '\n' | grep .); do


### PR DESCRIPTION
This should make it possible to assign groups that are created with another user.
e.g. 
```
adduser -D -H -u "3001" -s /bin/false "dummy1"
# won't work! (current behavior)
addgroup "dummy2" "3002

adduser -D -H -u "3002" -s /bin/false "dummy2"
```

```
adduser -D -H -u "3001" -s /bin/false "dummy1"
adduser -D -H -u "3002" -s /bin/false "dummy2"

# works (intendet new behavior)
addgroup "dummy2" "3002
```