### PR TITLE
Added nmbd service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache runit \
 
 VOLUME ["/shares"]
 
-EXPOSE 139 445
+EXPOSE 139 445 137/udp
 
 COPY . /container/
 

--- a/config/runit/nmbd/run
+++ b/config/runit/nmbd/run
@@ -1,0 +1,3 @@
+#!/bin/sh -x
+sleep 6
+exec nmbd --foreground


### PR DESCRIPTION
Added nmbd service to runit.
Was having issues in discovering the share in several places, for example in android I couldn't automatically discover shares in my network.

Probably a possible improvement will be to make the nmbd service only started by an environment variable check