### PR TITLE
External avahi doesn't work in the smbd-only and smbd-wsdd2 variants

### DIFF
--- a/generate-variants.sh
+++ b/generate-variants.sh
@@ -9,7 +9,7 @@ cd variants/smbd-only
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi | grep -v wsdd2 > Dockerfile.new
 mv Dockerfile.new Dockerfile
-rm -rf config/avahi config/runit/avahi
+rm -rf config/runit/avahi
 rm -rf config/runit/wsdd2
 
 sed -i.bak 's/:$TAG" --push/:smbd-only-$TAG" --push/g' build.sh && rm build.sh.bak
@@ -34,7 +34,7 @@ cd variants/smbd-wsdd2
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi > Dockerfile.new
 mv Dockerfile.new Dockerfile
-rm -rf config/avahi config/runit/avahi
+rm -rf config/runit/avahi
 
 sed -i.bak 's/:$TAG" --push/:smbd-wsdd2-$TAG" --push/g' build.sh && rm build.sh.bak
 sed -i.bak 's/:[l]atest/:smbd-wsdd2-latest/g' build.sh && rm build.sh.bak


### PR DESCRIPTION
`scripts/entrypoint.sh` assumes the existence of `/container/config/avahi/samba.service` and generates a lot of errors if it doesn't exist, starting with a failure copying it to `/etc/avahi/services/samba.service` and then nearly every place where the service is edited. Ultimately, this means that the service isn't available to be copied to `/external/avahi/samba.service` when the external avahi mount is detected.

Fortunately, this looks like a very easy fix; only the actual `samba.service` file is used by the `smbd-only` and `smbd-wsdd2` variants, so it should just be a matter of not deleting `config/avahi` when creating those variants.