### PR TITLE
Bump GitHub workflow actions to latest major versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,17 +36,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-          
+        uses: actions/checkout@v4
+
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,17 +56,17 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: New version needed?
-        id: docker_version_check          
+        id: docker_version_check
         run: |
           ./build.sh version-check
 
       - name: Extract Docker Version Tag
-        id: docker_version_tag          
+        id: docker_version_tag
         run: |
           ./get-version.sh $(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:" | tr '[:upper:]' '[:lower:]') | sed 's/^/tag=/g' >> $GITHUB_OUTPUT
           ./get-version.sh $(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:smbd-only-" | tr '[:upper:]' '[:lower:]') | sed 's/^/smbd_only_tag=/g' >> $GITHUB_OUTPUT
@@ -77,7 +77,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push Docker image - smbd-only
         id: build-and-push-smbd-only
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v5
         with:
           context: variants/smbd-only
           push: ${{ github.event_name != 'pull_request' }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build and push Docker image - smbd-avahi
         id: build-and-push-smbd-avahi
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v5
         with:
           context: variants/smbd-avahi
           push: ${{ github.event_name != 'pull_request' }}
@@ -117,7 +117,7 @@ jobs:
 
       - name: Build and push Docker image - smbd-wsdd2
         id: build-and-push-smbd-wsdd2
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v5
         with:
           context: variants/smbd-wsdd2
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This PR bumps all the used GitHub workflow actions to their latest major version.
If a more specific version is preferred, LMK!

Spotted in context of #130; this might even solve it?