### PR TITLE
Exclude unused files from docker image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# ignore everything
+*
+
+# except...
+!config
+!scripts


### PR DESCRIPTION
The PR includes a change to ignore files that should not be copied to the Docker image (eg: `.git` folder).

The layer instruction `COPY . /container/` in [Dockerfile](https://github.com/ServerContainers/samba/blob/914fb58048a3d49936963e3fc0ecee9b091fa6cd/Dockerfile#L29) copy all files in repository. 

There are many ways to solve this:
- create a folder for the build context and move config and scripts directories.
- More detailed copy on dockerfile layer instruction.
- add a .dockerignore file. (my chosen option)


The following screenshots are using a [dive ](https://github.com/wagoodman/dive) tool to inspect all the layers generated by the image.

**Current:**

![Screenshot 2024-05-26 204211](https://github.com/ServerContainers/samba/assets/38815440/35e0622c-4288-47d0-88cd-a3abe725f0af)


**After change:**

![Screenshot 2024-05-26 204046](https://github.com/ServerContainers/samba/assets/38815440/cab59e68-7578-48a6-b03b-16ce1246689a)
