### PR TITLE
Cleanup of various scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
-variants
+.github
+variants/**
+
+.gitignore
+docker-compose*.yml
 variants.tar

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ fi
 
 TAG=$(./get-version.sh)
 
-if echo "$@" | grep -v "force" 2>/dev/null >/dev/null; then  
+if echo "$@" | grep -v "force" 2>/dev/null >/dev/null; then
   # if there was a commit within the last hour, rebuild the container - even if it's already build
   ONE_HOUR_IN_SECONDS=3600
   EPOCH_SINCE_LAST_PUSH=$(git log -1 --format=%cd --date=iso | xargs -I {} date -d "{}" +%s || git log -1 --format=%cd --date=iso | xargs -I {} date -jf '%Y-%m-%d %H:%M:%S %z' "{}" +%s)
@@ -31,59 +31,9 @@ docker buildx build -q --pull --no-cache --platform "$PLATFORM" -t "$IMG:$TAG" -
 echo "$@" | grep "release" 2>/dev/null >/dev/null && echo ">> releasing new latest" && docker buildx build -q --pull --platform "$PLATFORM" -t "$IMG:latest" --push .
 
 # make sure to exit if this is only version check
-echo "$@" | grep "version-check" && exit 0 
+echo "$@" | grep "version-check" && exit 0
 
 # make sure this is only executed in main script
-echo "$@" | grep "variant" && exit 0 
+echo "$@" | grep "variant" && exit 0
 
-
-tar cf variants.tar --exclude .git/ --exclude variants.tar .
-
-mkdir -p variants/smbd-only variants/smbd-avahi variants/smbd-wsdd2
-
-
-cd variants/smbd-only
-tar xf ../../variants.tar
-cat Dockerfile | grep -v avahi | grep -v wsdd2 > Dockerfile.new
-echo "ENV WSDD2_DISABLE=disabled" >> Dockerfile.new
-echo "ENV AVAHI_DISABLE=disabled" >> Dockerfile.new
-mv Dockerfile.new Dockerfile
-rm -rf config/avahi config/runit/avahi
-rm -rf config/runit/wsdd2
-
-sed -i.bak 's/:$TAG" --push/:smbd-only-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-only-latest/g' build.sh && rm build.sh.bak
-
-./build.sh "variant" "$@"
-
-cd ../../
-
-
-cd variants/smbd-avahi
-tar xf ../../variants.tar
-cat Dockerfile | grep -v wsdd2 > Dockerfile.new
-echo "ENV WSDD2_DISABLE=disabled" >> Dockerfile.new
-mv Dockerfile.new Dockerfile
-rm -rf config/runit/wsdd2
-
-sed -i.bak 's/:$TAG" --push/:smbd-avahi-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-avahi-latest/g' build.sh && rm build.sh.bak
-
-./build.sh "variant" "$@"
-
-cd ../../
-
-
-cd variants/smbd-wsdd2
-tar xf ../../variants.tar
-cat Dockerfile | grep -v avahi > Dockerfile.new
-echo "ENV AVAHI_DISABLE=disabled" >> Dockerfile.new
-mv Dockerfile.new Dockerfile
-rm -rf config/avahi config/runit/avahi
-
-sed -i.bak 's/:$TAG" --push/:smbd-wsdd2-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-wsdd2-latest/g' build.sh && rm build.sh.bak
-
-./build.sh "variant" "$@"
-
-cd ../../
+./generate-variants.sh "build-image"

--- a/generate-variants.sh
+++ b/generate-variants.sh
@@ -5,6 +5,7 @@ tar cf variants.tar --exclude-ignore=.dockerignore .
 mkdir -p variants/smbd-only variants/smbd-avahi variants/smbd-wsdd2
 
 
+# create smbd-only variant
 cd variants/smbd-only
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi | grep -v wsdd2 > Dockerfile.new
@@ -15,17 +16,18 @@ rm -rf config/avahi
 rm -rf config/runit/avahi
 rm -rf config/runit/wsdd2
 
-sed -i.bak '/avahi/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healthcheck.sh.sh.bak
-sed -i.bak '/WSD/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healthcheck.sh.sh.bak
+sed -i '/avahi/d' ./scripts/docker-healthcheck.sh
+sed -i '/WSD/d' ./scripts/docker-healthcheck.sh
 
-sed -i.bak 's/:$TAG" --push/:smbd-only-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-only-latest/g' build.sh && rm build.sh.bak
+sed -i 's/:$TAG" --push/:smbd-only-$TAG" --push/g' build.sh
+sed -i 's/:[l]atest/:smbd-only-latest/g' build.sh
 
 # build variant if invocation mentions build
 echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
 
 cd ../../
 
+# create smbd-avahi variant
 cd variants/smbd-avahi
 tar xf ../../variants.tar
 cat Dockerfile | grep -v wsdd2 > Dockerfile.new
@@ -33,10 +35,10 @@ echo "ENV WSDD2_DISABLE=disabled" >> Dockerfile.new
 mv Dockerfile.new Dockerfile
 rm -rf config/runit/wsdd2
 
-sed -i.bak '/WSD/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healthcheck.sh.sh.bak
+sed -i '/WSD/d' ./scripts/docker-healthcheck.sh
 
-sed -i.bak 's/:$TAG" --push/:smbd-avahi-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-avahi-latest/g' build.sh && rm build.sh.bak
+sed -i 's/:$TAG" --push/:smbd-avahi-$TAG" --push/g' build.sh
+sed -i 's/:[l]atest/:smbd-avahi-latest/g' build.sh
 
 # build variant if invocation mentions build
 echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
@@ -44,6 +46,7 @@ echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
 cd ../../
 
 
+# create smbd-wsdd2 variant
 cd variants/smbd-wsdd2
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi > Dockerfile.new
@@ -52,10 +55,10 @@ mv Dockerfile.new Dockerfile
 rm -rf config/avahi
 rm -rf config/runit/avahi
 
-sed -i.bak '/avahi/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healthcheck.sh.sh.bak
+sed -i '/avahi/d' ./scripts/docker-healthcheck.sh
 
-sed -i.bak 's/:$TAG" --push/:smbd-wsdd2-$TAG" --push/g' build.sh && rm build.sh.bak
-sed -i.bak 's/:[l]atest/:smbd-wsdd2-latest/g' build.sh && rm build.sh.bak
+sed -i 's/:$TAG" --push/:smbd-wsdd2-$TAG" --push/g' build.sh
+sed -i 's/:[l]atest/:smbd-wsdd2-latest/g' build.sh
 
 # build variant if invocation mentions build
 echo "$@" | grep "build-image" && ./build.sh "variant" "$@"

--- a/generate-variants.sh
+++ b/generate-variants.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-tar cf variants.tar --exclude .git/ --exclude variants.tar .
+tar cf variants.tar --exclude-ignore=.dockerignore .
 
 mkdir -p variants/smbd-only variants/smbd-avahi variants/smbd-wsdd2
 

--- a/generate-variants.sh
+++ b/generate-variants.sh
@@ -8,7 +8,10 @@ mkdir -p variants/smbd-only variants/smbd-avahi variants/smbd-wsdd2
 cd variants/smbd-only
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi | grep -v wsdd2 > Dockerfile.new
+echo "ENV WSDD2_DISABLE=disabled" >> Dockerfile.new
+echo "ENV AVAHI_DISABLE=disabled" >> Dockerfile.new
 mv Dockerfile.new Dockerfile
+rm -rf config/avahi
 rm -rf config/runit/avahi
 rm -rf config/runit/wsdd2
 
@@ -18,12 +21,15 @@ sed -i.bak '/WSD/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healt
 sed -i.bak 's/:$TAG" --push/:smbd-only-$TAG" --push/g' build.sh && rm build.sh.bak
 sed -i.bak 's/:[l]atest/:smbd-only-latest/g' build.sh && rm build.sh.bak
 
-cd ../../
+# build variant if invocation mentions build
+echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
 
+cd ../../
 
 cd variants/smbd-avahi
 tar xf ../../variants.tar
 cat Dockerfile | grep -v wsdd2 > Dockerfile.new
+echo "ENV WSDD2_DISABLE=disabled" >> Dockerfile.new
 mv Dockerfile.new Dockerfile
 rm -rf config/runit/wsdd2
 
@@ -32,18 +38,26 @@ sed -i.bak '/WSD/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healt
 sed -i.bak 's/:$TAG" --push/:smbd-avahi-$TAG" --push/g' build.sh && rm build.sh.bak
 sed -i.bak 's/:[l]atest/:smbd-avahi-latest/g' build.sh && rm build.sh.bak
 
+# build variant if invocation mentions build
+echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
+
 cd ../../
 
 
 cd variants/smbd-wsdd2
 tar xf ../../variants.tar
 cat Dockerfile | grep -v avahi > Dockerfile.new
+echo "ENV AVAHI_DISABLE=disabled" >> Dockerfile.new
 mv Dockerfile.new Dockerfile
+rm -rf config/avahi
 rm -rf config/runit/avahi
 
 sed -i.bak '/avahi/d' ./scripts/docker-healthcheck.sh && rm ./scripts/docker-healthcheck.sh.sh.bak
 
 sed -i.bak 's/:$TAG" --push/:smbd-wsdd2-$TAG" --push/g' build.sh && rm build.sh.bak
 sed -i.bak 's/:[l]atest/:smbd-wsdd2-latest/g' build.sh && rm build.sh.bak
+
+# build variant if invocation mentions build
+echo "$@" | grep "build-image" && ./build.sh "variant" "$@"
 
 cd ../../

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -30,7 +30,7 @@ if [ ! -f "$INITALIZED" ]; then
   echo ">> CONTAINER: starting initialisation"
 
   cp /container/config/samba/smb.conf /etc/samba/smb.conf
-  cp /container/config/avahi/samba.service /etc/avahi/services/samba.service
+  [ ! -z ${AVAHI_DISABLE+x} ] || cp /container/config/avahi/samba.service /etc/avahi/services/samba.service
 
   ##
   # FRUIT DISABLE
@@ -149,7 +149,7 @@ if [ ! -f "$INITALIZED" ]; then
       echo -e "$ACCOUNT_PASSWORD\n$ACCOUNT_PASSWORD" | passwd "$ACCOUNT_NAME"
       echo -e "$ACCOUNT_PASSWORD\n$ACCOUNT_PASSWORD" | smbpasswd "$ACCOUNT_NAME"
     fi
-    
+
     smbpasswd -e "$ACCOUNT_NAME"
   done
 
@@ -182,7 +182,7 @@ if [ ! -f "$INITALIZED" ]; then
   [ -z ${MODEL+x} ] && MODEL="TimeCapsule"
   sed -i 's/TimeCapsule/'"$MODEL"'/g' /etc/samba/smb.conf
 
-  if ! grep '<txt-record>model=' /etc/avahi/services/samba.service 2> /dev/null >/dev/null;
+  if [ -f /etc/avahi/services/samba.service ] && ! grep '<txt-record>model=' /etc/avahi/services/samba.service 2> /dev/null >/dev/null;
   then
     # remove </service-group>
     sed -i '/<\/service-group>/d' /etc/avahi/services/samba.service
@@ -262,7 +262,7 @@ if [ ! -f "$INITALIZED" ]; then
 ' >> /etc/samba/smb.conf
     fi
 
-    if echo "$VOL_PATH" | grep '%U$' 2>/dev/null >/dev/null; 
+    if echo "$VOL_PATH" | grep '%U$' 2>/dev/null >/dev/null;
     then
       VOL_PATH_BASE=$(echo "$VOL_PATH" | sed 's,/%U$,,g')
       echo "  >> multiuser volume - $VOL_PATH"
@@ -277,16 +277,20 @@ if [ ! -f "$INITALIZED" ]; then
   [ ! -z ${AVAHI_NAME+x} ] && echo ">> ZEROCONF: custom avahi avahi-daemon.conf host-name: $AVAHI_NAME" && sed -i "s/#host-name=.*/host-name=${AVAHI_NAME}/" /etc/avahi/avahi-daemon.conf
   [ ! -z ${AVAHI_INTERFACES+x} ] && echo ">> ZEROCONF: custom avahi avahi-daemon.conf allow-interfaces: $AVAHI_INTERFACES" && sed -i "s/#allow-interfaces=.*/allow-interfaces=${AVAHI_INTERFACES}/" /etc/avahi/avahi-daemon.conf
 
-  echo ">> ZEROCONF: samba.service file"
-  echo "############################### START ####################################"
-  cat /etc/avahi/services/samba.service
-  echo "################################ END #####################################"
+  if [ -z ${AVAHI_DISABLE+x} ]
+  then
+    echo ">> ZEROCONF: samba.service file"
+    echo "############################### START ####################################"
+    cat /etc/avahi/services/samba.service
+    echo "################################ END #####################################"
+  else
+    echo ">> AVAHI - DISABLED"
+    rm -rf /container/config/runit/avahi
+  fi
 
   [ ! -z ${WSDD2_PARAMETERS+x} ] && echo ">> WSDD2: custom parameters for wsdd2 daemon: wsdd2 $WSDD2_PARAMETERS" && sed -i 's/wsdd2/wsdd2 '"$WSDD2_PARAMETERS"'/g' /container/config/runit/wsdd2/run
 
   [ ! -z ${WSDD2_DISABLE+x} ] && echo ">> WSDD2 - DISABLED" && rm -rf /container/config/runit/wsdd2
-
-  [ ! -z ${AVAHI_DISABLE+x} ] && echo ">> AVAHI - DISABLED" && rm -rf /container/config/runit/avahi
 
   [ ! -z ${NETBIOS_DISABLE+x} ] && echo ">> NETBIOS - DISABLED" && rm -rf /container/config/runit/nmbd
 
@@ -300,7 +304,7 @@ if [ ! -f "$INITALIZED" ]; then
     echo ">> EXTERNAL AVAHI: list of services"
     ls -l /external/avahi/*.service
   fi
-  
+
   echo ""
   echo ">> SAMBA: check smb.conf file using 'testparm -s'"
   echo "############################### START ####################################"


### PR DESCRIPTION
When looking into #147 and wondering whether or not the `smbd-only` tag would be suitable for our usecase, I noticed that when using this variant I was faced with various Avahi-related warnings when booting this image, making me wonder whether or not I had it properly configured. However, it seems like they are caused by a combination of:
- `AVAHI_DISABLE` not being set in the images (this was missing from `generate-variants.sh`
- some entrypoint logic not being disabled when `AVAHI_DISABLE` is set

I figured this was caused by some mismatching between logic in `build.sh` and `generate-variants.sh`. Therefore I've opted to merge the scripts, using an argument-keyword-detection system in `generate-variants.sh` to distinguish "generate" and "generate+build" mode. Furthermore, I've opted to disable some additional logic in the entrypoint script by checking for `AVAHI_DISABLE`.

Finally, I ran into some issues with `generate-variants` becoming slower on repeated runs, due to nested tar'ing of the `variants` directory, which I removed by using `.dockerignore` as ignore-file and adding some additional files/folders to it.

For reference, the warnings can be reproduced with e.g.: `docker run --rm ghcr.io/servercontainers/samba:smbd-only-a3.20.3-s4.19.9-r0 /bin/sh -c "echo 'debug done'"`:
```
################################################################################

Welcome to the ghcr.io/servercontainers/samba

################################################################################

You'll find this container sourcecode here:

    https://github.com/ServerContainers/samba

The container repository will be updated regularly.

################################################################################


mkdir: can't create directory '/var/run/samba': File exists
>> CONTAINER: starting initialisation
cp: can't create '/etc/avahi/services/samba.service': No such file or directory
>> SAMBA CONFIG: no $SAMBA_CONF_LOG_LEVEL set, using '1'
>> SAMBA CONFIG: no $SAMBA_CONF_WORKGROUP set, using 'WORKGROUP'
>> SAMBA CONFIG: no $SAMBA_CONF_SERVER_STRING set, using 'Samba Server'
>> SAMBA CONFIG: no $SAMBA_CONF_MAP_TO_GUEST set, using 'Bad User'
sed: /etc/avahi/services/samba.service: No such file or directory
  >> AVAHI: zeroconf model: TimeCapsule
/container/scripts/entrypoint.sh: line 173: can't create /etc/avahi/services/samba.service: nonexistent directory
>> ZEROCONF: samba.service file
############################### START ####################################
cat: can't open '/etc/avahi/services/samba.service': No such file or directory
################################ END #####################################
>> EXTERNAL AVAHI: found external avahi, now maintaining avahi service file 'samba.service'
>> EXTERNAL AVAHI: internal avahi gets disabled
cp: can't stat '/etc/avahi/services/samba.service': No such file or directory
>> EXTERNAL AVAHI: list of services
chmod: /external/avahi/samba.service: No such file or directory
ls: /external/avahi/*.service: No such file or directory

>> SAMBA: check smb.conf file using 'testparm -s'
############################### START ####################################
Load smb config files from /etc/samba/smb.conf
Loaded services file OK.
Weak crypto is allowed by GnuTLS (e.g. NTLM as a compatibility fallback)

Server role: ROLE_STANDALONE

# Global parameters
[global]
        dns proxy = No
        load printers = No
        log file = /dev/stdout
        map to guest = Bad User
        obey pam restrictions = Yes
        passdb backend = smbpasswd
        printcap name = /dev/null
        security = USER
        server role = standalone server
        server string = Samba Server
        smb1 unix extensions = No
        fruit:aapl = yes
        fruit:model = TimeCapsule
        idmap config * : backend = tdb
        acl allow execute always = Yes
        mangled names = no
        vfs objects = catia fruit streams_xattr
        wide links = Yes
############################### END ####################################


>> SAMBA: print whole smb.conf
############################### START ####################################
[global]
   server role = standalone server
   log file = /dev/stdout
   dns proxy = no

   # password stuff
   passdb backend = smbpasswd

   obey pam restrictions = yes
   security = user
   printcap name = /dev/null
   load printers = no
   dns proxy = no
   wide links = yes
   follow symlinks = yes
   unix extensions = no
   acl allow execute always = yes

   # MacOS Compatibility options
   vfs objects = catia fruit streams_xattr

   # Special configuration for Apple's Time Machine
   fruit:model = TimeCapsule
   fruit:aapl = yes

   # fix filenames with special chars (should be default)
   mangled names = no
   dos charset = CP850
   unix charset = UTF-8

   # Docker Envs global config options
   log level = 1
   workgroup = WORKGROUP
   server string = Samba Server
   map to guest = Bad User

############################### END ####################################

>> CMD: exec docker CMD
/bin/sh -c echo 'debug done'
debug done
```

After this MR the output is as follows:
```
################################################################################

Welcome to the ghcr.io/servercontainers/samba

################################################################################

You'll find this container sourcecode here:

    https://github.com/ServerContainers/samba

The container repository will be updated regularly.

################################################################################


mkdir: can't create directory '/var/run/samba': File exists
>> CONTAINER: starting initialisation
>> SAMBA CONFIG: no $SAMBA_CONF_LOG_LEVEL set, using '1'
>> SAMBA CONFIG: no $SAMBA_CONF_WORKGROUP set, using 'WORKGROUP'
>> SAMBA CONFIG: no $SAMBA_CONF_SERVER_STRING set, using 'Samba Server'
>> SAMBA CONFIG: no $SAMBA_CONF_MAP_TO_GUEST set, using 'Bad User'
>> AVAHI - DISABLED
>> WSDD2 - DISABLED

>> SAMBA: check smb.conf file using 'testparm -s'
############################### START ####################################
Load smb config files from /etc/samba/smb.conf
Loaded services file OK.
Weak crypto is allowed by GnuTLS (e.g. NTLM as a compatibility fallback)

Server role: ROLE_STANDALONE

# Global parameters
[global]
        dns proxy = No
        load printers = No
        log file = /dev/stdout
        map to guest = Bad User
        obey pam restrictions = Yes
        passdb backend = smbpasswd
        printcap name = /dev/null
        security = USER
        server role = standalone server
        server string = Samba Server
        smb1 unix extensions = No
        fruit:aapl = yes
        fruit:model = TimeCapsule
        idmap config * : backend = tdb
        acl allow execute always = Yes
        mangled names = no
        vfs objects = catia fruit streams_xattr
        wide links = Yes
############################### END ####################################


>> SAMBA: print whole smb.conf
############################### START ####################################
[global]
   server role = standalone server
   log file = /dev/stdout
   dns proxy = no

   # password stuff
   passdb backend = smbpasswd

   obey pam restrictions = yes
   security = user
   printcap name = /dev/null
   load printers = no
   dns proxy = no
   wide links = yes
   follow symlinks = yes
   unix extensions = no
   acl allow execute always = yes

   # MacOS Compatibility options
   vfs objects = catia fruit streams_xattr

   # Special configuration for Apple's Time Machine
   fruit:model = TimeCapsule
   fruit:aapl = yes

   # fix filenames with special chars (should be default)
   mangled names = no
   dos charset = CP850
   unix charset = UTF-8

   # Docker Envs global config options
   log level = 1
   workgroup = WORKGROUP
   server string = Samba Server
   map to guest = Bad User

############################### END ####################################

>> CMD: exec docker CMD
/bin/sh -c echo 'debug done'
debug done
```