### PR TITLE
Stabilize UID/GID handling: create users before groups

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -92,17 +92,6 @@ if [ ! -f "$INITALIZED" ]; then
   [ ! -z ${FAIL_FAST+x} ] && set -e
 
   ##
-  # Create GROUPS
-  ##
-  for I_CONF in $(env | grep '^GROUP_')
-  do
-    GROUP_NAME=$(echo "$I_CONF" | sed 's/^GROUP_//g' | sed 's/=.*//g')
-    GROUP_ID=$(echo "$I_CONF" | sed 's/^[^=]*=//g')
-    echo ">> GROUP: adding group $GROUP_NAME with GID: $GROUP_ID"
-    addgroup -g "$GROUP_ID" "$GROUP_NAME"
-  done
-
-  ##
   # Create USER ACCOUNTS
   ##
   for I_ACCOUNT in $(env | grep '^ACCOUNT_')
@@ -133,6 +122,17 @@ if [ ! -f "$INITALIZED" ]; then
     fi
     
     smbpasswd -e "$ACCOUNT_NAME"
+  done
+  
+  ##
+  # Create GROUPS
+  ##
+  for I_CONF in $(env | grep '^GROUP_')
+  do
+    GROUP_NAME=$(echo "$I_CONF" | sed 's/^GROUP_//g' | sed 's/=.*//g')
+    GROUP_ID=$(echo "$I_CONF" | sed 's/^[^=]*=//g')
+    echo ">> GROUP: adding group $GROUP_NAME with GID: $GROUP_ID"
+    addgroup -g "$GROUP_ID" "$GROUP_NAME"
   done
 
   ##


### PR DESCRIPTION
### Summary
Currently the entrypoint creates groups before users. On Alpine, this can cause
user creation to fail if a `GROUP_*` and an `ACCOUNT_*` are configured with the
same numeric ID (e.g. UID=1000 and GID=1000). In this case `adduser` fails and
Samba does not export the shares.

By creating users first, the UID can always be allocated. If the same numeric
GID is later requested, `addgroup` fails harmlessly with "gid in use". The user
is still created successfully and the container continues normally.

### Benefits
- Prevents confusing failures when UID and GID collide in env configuration.
- Still works for all existing setups (no regressions).
- Safer and more predictable behavior in environments where UID=GID mappings are
  common for volume ownership.

### Notes
This does not claim that UID=GID was previously impossible in all cases. It was
always possible if no `GROUP_*` collided. The change simply hardens the
entrypoint against collisions when both are defined.
