### PR TITLE
added avahi allow-interfaces option

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -275,6 +275,7 @@ if [ ! -f "$INITALIZED" ]; then
 
   [ ! -z ${AVAHI_NAME+x} ] && echo ">> ZEROCONF: custom avahi samba.service name: $AVAHI_NAME" && sed -i 's/%h/'"$AVAHI_NAME"'/g' /etc/avahi/services/samba.service
   [ ! -z ${AVAHI_NAME+x} ] && echo ">> ZEROCONF: custom avahi avahi-daemon.conf host-name: $AVAHI_NAME" && sed -i "s/#host-name=foo/host-name=${AVAHI_NAME}/" /etc/avahi/avahi-daemon.conf
+  [ ! -z ${AVAHI_INTERFACES+x} ] && echo ">> ZEROCONF: custom avahi avahi-daemon.conf allow-interfaces: $AVAHI_INTERFACES" && sed -i "s/#allow-interfaces=eth0/allow-interfaces=${AVAHI_INTERFACES}/" /etc/avahi/avahi-daemon.conf
 
   echo ">> ZEROCONF: samba.service file"
   echo "############################### START ####################################"


### PR DESCRIPTION
**allow-interfaces=** Set a comma seperated list of allowed network interfaces that should be used by the avahi-daemon. Other interfaces will be ignored. If set to the empty list all local interfaces except loopback and point-to-point will be used. 

Closes #166 