### PR TITLE
Fix Alpine 3.23 builds by force-updating apk-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine AS wsdd2-builder
 
+# Temporary fix for Alpine 3.23
+RUN apk upgrade --no-cache --no-scripts apk-tools
+
 RUN apk add --no-cache make gcc libc-dev linux-headers && wget -O - https://github.com/Netgear/wsdd2/archive/refs/heads/master.tar.gz | tar zxvf - \
  && cd wsdd2-master && sed -i 's/-O0/-O0 -Wno-int-conversion/g' Makefile && make
 
@@ -9,6 +12,9 @@ FROM alpine
 COPY --from=wsdd2-builder /wsdd2-master/wsdd2 /usr/sbin
 
 ENV PATH="/container/scripts:${PATH}"
+
+# Temporary fix for Alpine 3.23
+RUN apk upgrade --no-cache --no-scripts apk-tools
 
 RUN apk add --no-cache runit \
                        tzdata \


### PR DESCRIPTION
Current image build jobs are failing due to the update to Alpine 3.23, see e.g. https://github.com/ServerContainers/samba/actions/runs/20080713627/job/57606814068. This is caused by the issue described at https://gitlab.alpinelinux.org/alpine/aports/-/issues/17775. Although not entirely resolved yet, an update to `apk-tools` has been issued which should effectively solve this issue. This PR aims to fix builds by forcing this update to be pulled on building. It can be reverted once the base Alpine Docker image includes this version by default.

Note: I've not yet tested if this actually fixes builds, but CI should show that soon enough...?