### PR TITLE
Add 'Set up QEMU' to docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
   DOCKER_REGISTRY: ghcr.io/servercontainers
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
+  IMAGE_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
 jobs:
   build:
@@ -41,7 +41,12 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
-        
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.IMAGE_PLATFORMS }}
+
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -88,7 +93,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_version_tag.outputs.tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -111,7 +116,7 @@ jobs:
           context: variants/smbd-only
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_version_tag.outputs.smbd_only_tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -129,7 +134,7 @@ jobs:
           context: variants/smbd-avahi
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_version_tag.outputs.smbd_avahi_tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -147,7 +152,7 @@ jobs:
           context: variants/smbd-wsdd2
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_version_tag.outputs.smbd_wsdd2_tag }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
As a replacement to #168, this PR aims to address the current build issue by manually setting up QEMU before building Docker images.